### PR TITLE
fix: add determistic hash in selectors to handle conflicting styles

### DIFF
--- a/src/__tests__/index.web.test.tsx
+++ b/src/__tests__/index.web.test.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react-native';
 //@ts-ignore
 import createStyleResolver from 'react-native-web/dist/exports/StyleSheet/createStyleResolver';
 import { View } from 'react-native';
+import stableHash from 'stable-hash';
+import hash from '../hash';
 
 let styleResolver: any;
 
@@ -15,20 +17,23 @@ describe('test responsive styles', () => {
   });
 
   it('verifies min width query', () => {
-    const App = () => {
-      const { styles } = useResponsiveQuery({
-        initial: {
-          backgroundColor: 'yellow',
-        },
-        query: [
-          {
-            minWidth: 500,
-            style: {
-              backgroundColor: 'black',
-            },
+    const query = {
+      initial: {
+        backgroundColor: 'yellow',
+      },
+      query: [
+        {
+          minWidth: 500,
+          style: {
+            backgroundColor: 'black',
           },
-        ],
-      });
+        },
+      ],
+    };
+    const identifierHash = hash(stableHash(query));
+
+    const App = () => {
+      const { styles } = useResponsiveQuery(query);
 
       return <View testID="test" style={styles} />;
     };
@@ -37,31 +42,34 @@ describe('test responsive styles', () => {
     const view = getByTestId('test');
     expect(view.props.style).toEqual([{ backgroundColor: 'yellow' }]);
     expect(styleResolver.sheet.getTextContent()).toContain(
-      '/*[data-min-width-500-r-backgroundcolor-kemksi]{}*/@media only screen and (min-width: 500px) { [data-min-width-500-r-backgroundcolor-kemksi]{background-color:rgba(0,0,0,1.00);} }'
+      `/*[data-min-width-500-r-backgroundcolor-kemksi-${identifierHash}]{}*/@media only screen and (min-width: 500px) { [data-min-width-500-r-backgroundcolor-kemksi-${identifierHash}]{background-color:rgba(0,0,0,1.00);} }`
     );
   });
 
   it('verifies min width and max width query', () => {
-    const App = () => {
-      const { styles } = useResponsiveQuery({
-        initial: {
-          backgroundColor: 'yellow',
+    const query = {
+      initial: {
+        backgroundColor: 'yellow',
+      },
+      query: [
+        {
+          maxWidth: 400,
+          style: {
+            backgroundColor: 'black',
+          },
         },
-        query: [
-          {
-            maxWidth: 400,
-            style: {
-              backgroundColor: 'black',
-            },
+        {
+          minWidth: 400,
+          style: {
+            backgroundColor: 'pink',
           },
-          {
-            minWidth: 400,
-            style: {
-              backgroundColor: 'pink',
-            },
-          },
-        ],
-      });
+        },
+      ],
+    };
+    const identifierHash = hash(stableHash(query));
+
+    const App = () => {
+      const { styles } = useResponsiveQuery(query);
 
       return <View testID="test" style={styles} />;
     };
@@ -70,40 +78,43 @@ describe('test responsive styles', () => {
     const view = getByTestId('test');
     expect(view.props.style).toEqual([{ backgroundColor: 'yellow' }]);
     expect(styleResolver.sheet.getTextContent()).toContain(
-      `/*[data-max-width-400-r-backgroundcolor-kemksi]{}*/@media only screen and (max-width: 400px) { [data-max-width-400-r-backgroundcolor-kemksi]{background-color:rgba(0,0,0,1.00);} }`
+      `/*[data-max-width-400-r-backgroundcolor-kemksi-${identifierHash}]{}*/@media only screen and (max-width: 400px) { [data-max-width-400-r-backgroundcolor-kemksi-${identifierHash}]{background-color:rgba(0,0,0,1.00);} }`
     );
     expect(styleResolver.sheet.getTextContent()).toContain(
-      `/*[data-min-width-400-r-backgroundcolor-bwrkcz]{}*/@media only screen and (min-width: 400px) { [data-min-width-400-r-backgroundcolor-bwrkcz]{background-color:rgba(255,192,203,1.00);} }`
+      `/*[data-min-width-400-r-backgroundcolor-bwrkcz-${identifierHash}]{}*/@media only screen and (min-width: 400px) { [data-min-width-400-r-backgroundcolor-bwrkcz-${identifierHash}]{background-color:rgba(255,192,203,1.00);} }`
     );
   });
 
   it('verifies min width and max width array queries', () => {
-    const App = () => {
-      const { styles } = useResponsiveQuery({
-        initial: [
-          {
-            backgroundColor: 'yellow',
-          },
-          { height: 100 },
-        ],
-        query: [
-          {
-            maxWidth: 400,
-            style: [
-              {
-                backgroundColor: 'black',
-              },
-              { maxHeight: 200 },
-            ],
-          },
-          {
-            minWidth: 400,
-            style: {
-              backgroundColor: 'pink',
+    const query = {
+      initial: [
+        {
+          backgroundColor: 'yellow',
+        },
+        { height: 100 },
+      ],
+      query: [
+        {
+          maxWidth: 400,
+          style: [
+            {
+              backgroundColor: 'black',
             },
+            { maxHeight: 200 },
+          ],
+        },
+        {
+          minWidth: 400,
+          style: {
+            backgroundColor: 'pink',
           },
-        ],
-      });
+        },
+      ],
+    };
+
+    const identifierHash = hash(stableHash(query));
+    const App = () => {
+      const { styles } = useResponsiveQuery(query);
 
       return <View testID="test" style={styles} />;
     };
@@ -115,13 +126,13 @@ describe('test responsive styles', () => {
     ]);
     console.log('text content', styleResolver.sheet.getTextContent());
     expect(styleResolver.sheet.getTextContent()).toContain(
-      `/*[data-max-width-400-r-backgroundcolor-kemksi]{}*/@media only screen and (max-width: 400px) { [data-max-width-400-r-backgroundcolor-kemksi]{background-color:rgba(0,0,0,1.00);} }`
+      `/*[data-max-width-400-r-backgroundcolor-kemksi-${identifierHash}]{}*/@media only screen and (max-width: 400px) { [data-max-width-400-r-backgroundcolor-kemksi-${identifierHash}]{background-color:rgba(0,0,0,1.00);} }`
     );
     expect(styleResolver.sheet.getTextContent()).toContain(
-      `/*[data-max-width-400-r-maxheight-1uq9rlk]{}*/@media only screen and (max-width: 400px) { [data-max-width-400-r-maxheight-1uq9rlk]{max-height:200px;} }`
+      `/*[data-max-width-400-r-maxheight-1uq9rlk-${identifierHash}]{}*/@media only screen and (max-width: 400px) { [data-max-width-400-r-maxheight-1uq9rlk-${identifierHash}]{max-height:200px;} }`
     );
     expect(styleResolver.sheet.getTextContent()).toContain(
-      `/*[data-min-width-400-r-backgroundcolor-bwrkcz]{}*/@media only screen and (min-width: 400px) { [data-min-width-400-r-backgroundcolor-bwrkcz]{background-color:rgba(255,192,203,1.00);} }`
+      `/*[data-min-width-400-r-backgroundcolor-bwrkcz-${identifierHash}]{}*/@media only screen and (min-width: 400px) { [data-min-width-400-r-backgroundcolor-bwrkcz-${identifierHash}]{background-color:rgba(255,192,203,1.00);} }`
     );
   });
 });

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,0 +1,65 @@
+/* eslint-disable */
+//@ts-nocheck
+// This hash function is taken from react native web
+/**
+ * JS Implementation of MurmurHash2
+ *
+ * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+ * @see http://github.com/garycourt/murmurhash-js
+ * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
+ * @see http://sites.google.com/site/murmurhash/
+ *
+ * @param {string} str ASCII only
+ * @param {number} seed Positive integer only
+ * @return {number} 32-bit positive integer hash
+ */
+function murmurhash2_32_gc(str: string, seed: number) {
+  var l = str.length,
+    h = seed ^ l,
+    i = 0,
+    k;
+
+  while (l >= 4) {
+    k =
+      (str.charCodeAt(i) & 0xff) |
+      ((str.charCodeAt(++i) & 0xff) << 8) |
+      ((str.charCodeAt(++i) & 0xff) << 16) |
+      ((str.charCodeAt(++i) & 0xff) << 24);
+    k =
+      (k & 0xffff) * 0x5bd1e995 + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16);
+    k ^= k >>> 24;
+    k =
+      (k & 0xffff) * 0x5bd1e995 + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16);
+    h =
+      ((h & 0xffff) * 0x5bd1e995 +
+        ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)) ^
+      k;
+    l -= 4;
+    ++i;
+  }
+
+  switch (l) {
+    case 3:
+      h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
+
+    case 2:
+      h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
+
+    case 1:
+      h ^= str.charCodeAt(i) & 0xff;
+      h =
+        (h & 0xffff) * 0x5bd1e995 +
+        ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16);
+  }
+
+  h ^= h >>> 13;
+  h = (h & 0xffff) * 0x5bd1e995 + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16);
+  h ^= h >>> 15;
+  return h >>> 0;
+}
+
+const hash = function hash(str: string) {
+  return murmurhash2_32_gc(str, 1).toString(36);
+};
+
+export default hash;


### PR DESCRIPTION
Append a deterministic hash to data attributes to handle conflicting styles in query array order when more than one media query matches.

Since the returned value from this hash will be deterministic (it depends upon the styles) it would be strict mode compatible.

## Issue
Using media queries as atomic class selectors is difficult as multiple queries can match at the same time. In the below example, both the view will be styled exactly the same when width < 800. Ideally, in the second query, the `minWidth` should've been given higher priority as it comes last in the array. The only way to achieve I can think of to achieve this is by giving a unique id to data attributes in `useResponsiveQuery`. This will make sure that it prefers the incoming array order. The downside would be that rules will not be reusable throughout the app like atomic rules.

```js
const { dataSet } = useResponsiveQuery({
    query: [
      {
        minWidth: 400,
        style: { backgroundColor: 'black' },
      },
      {
        maxWidth: 800,
        style: { backgroundColor: 'blue' },
      },
    ],
  });

  const { dataSet: dataSet2 } = useResponsiveQuery({
    query: [
      {
        maxWidth: 800,
        style: { backgroundColor: 'blue' },
      },
      {
        minWidth: 400,
        style: { backgroundColor: 'black' },
      },
    ],
  });

  return (
    <>
      <View
        dataSet={dataSet}
        style={{ height: 100, width: 100 }}
      />
      <View
        dataSet={dataSet2}
        style={{ height: 100, width: 100 }}
      />
    </>
  );
}
```